### PR TITLE
Update documentation / Galaxy meta information

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ aws_efs_paths:
 
 ### Mandatory variables
 
-```
+```yaml
 aws_efs_paths:
 - path: ""
   owner: ""

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Basic usage is:
 
 With all variables explicitely defined:
 
-```
+```yaml
 - hosts: all
   roles:
   - role: thiagoalmeidasa.aws_efs
@@ -75,26 +75,18 @@ But I often add it as a submdule in a given `playbook_dir` repository.
 git submodule add git@github.com:thiagoalmeidasa/ansible-role-aws-efs.git <playbook_dir>/roles/aws_efs
 ```
 
+Include role this way:
+
+```yaml
+- hosts: all
+  roles:
+  - role: aws_efs
+```
+
 As the role is not managed by Ansible Galaxy, you do not have to specify the
 github user account.
 
 ## Role Variables
-
-Variables are divided in three types.
-
-The [default vars](#default-vars) section shows you which variables you may
-override in your ansible inventory. As a matter of fact, all variables should
-be defined there for explicitness, ease of documentation as well as overall
-role manageability.
-
-The [mandatory variables](#mandatory-variables) section contains variables that
-for several reasons do not fit into the default variables. As name implies,
-they must absolutely be defined in the inventory or else the role will
-fail. It is a good thing to avoid reach for these as much as possible and/or
-design the role with clear behavior when they're undefined.
-
-The [context variables](#context-variables) are shown in section below hint you
-on how runtime context may affects role execution.
 
 ### Default vars
 

--- a/README.md
+++ b/README.md
@@ -44,6 +44,23 @@ Basic usage is:
         filesystem_id: "fs-someid"
 ```
 
+With all variables explicitely defined:
+
+```
+- hosts: all
+  roles:
+  - role: thiagoalmeidasa.aws_efs
+    vars:
+      aws_efs_paths:
+      - path: "/path"
+        owner: "root"
+        group: "root"
+        mode: "0644"
+        region: "eu-west-1"
+        filesystem_id: "fs-someid"
+        state: "mounted",
+        opts: "nfsvers=4.1,rsize=1048576,wsize=1048576,hard,timeo=600,retrans=2"
+```
 ### Install with git
 
 If you do not want a global installation, clone it into your `roles_path`.

--- a/README.md
+++ b/README.md
@@ -36,22 +36,12 @@ Basic usage is:
   - role: thiagoalmeidasa.aws_efs
     vars:
       aws_efs_paths:
-      - path: "/some/path",
-        owner: "root",
-        group: "root",
-        mode: "0644",
-        region: "eu-west-1",
-        filesystem_id: "fs-someid",
-        state: "mounted",
-        opts: "nfsvers=4.1"
-      - path: "/some/other/path",
-        owner: "root",
-        group: "root",
-        mode: "0755",
-        region: "eu-west-1",
-        filesystem_id: "fs-someotherid",
-        state: "mounted",
-        opts: "nfsvers=4.1,rsize=1048576,wsize=1048576,hard,timeo=600,retrans=2"
+      - path: "/path"
+        owner: "root"
+        group: "root"
+        mode: "0644"
+        region: "eu-west-1"
+        filesystem_id: "fs-someid"
 ```
 
 ### Install with git
@@ -70,32 +60,6 @@ git submodule add git@github.com:thiagoalmeidasa/ansible-role-aws-efs.git <playb
 
 As the role is not managed by Ansible Galaxy, you do not have to specify the
 github user account.
-
-Basic usage is:
-
-```yaml
-- hosts: all
-  roles:
-  - role: aws_efs
-    vars:
-      aws_efs_paths:
-      - path: "/some/path",
-        owner: "root",
-        group: "root",
-        mode: "0644",
-        region: "eu-west-1",
-        filesystem_id: "fs-someid",
-        state: "mounted",
-        opts: "nfsvers=4.1"
-      - path: "/some/other/path",
-        owner: "root",
-        group: "root",
-        mode: "0755",
-        region: "eu-west-1",
-        filesystem_id: "fs-someotherid",
-        state: "mounted",
-        opts: "nfsvers=4.1,rsize=1048576,wsize=1048576,hard,timeo=600,retrans=2"
-```
 
 ## Role Variables
 
@@ -158,8 +122,6 @@ aws_efs_paths:
   mode: ""
   region: ""
   filesystem_id: ""
-  state: ""
-  opts: ""
 ```
 
 ### Context variables

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -8,9 +8,18 @@ galaxy_info:
   license: "license (BSD, MIT)"
   min_ansible_version: 2.0
   platforms:
+  - name: EL
+    versions:
+      - all
+  - name: Fedora
+    versions:
+      - all
+  - name: Debian
+    versions:
+      - all
   - name: Ubuntu
     versions:
-    - xenial
+      - xenial
   galaxy_tags:
     - beta
     - amazon


### PR DESCRIPTION
There's some commas in the example code which obviously doesn't work

documentation mentions all variables required, but actually mounted and opts have defaults.

Galaxy meta mentions only Ubuntu supported, but the code actually supports RHEL based platforms.

I successful used this on CentOS, don't have data to verify all the platforms, good idea to add some basic automated testing in the future that can verify this.