### PR TITLE
use IMDSv2 access token when getting AZ

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -10,9 +10,20 @@
     state: present
   when: ansible_os_family == 'RedHat'
 
+- name: Get IMDSv2 access token
+  uri:
+    url: http://169.254.169.254/latest/api/token
+    method: PUT
+    headers:
+      X-aws-ec2-metadata-token-ttl-seconds: 10
+    return_content: yes
+  register: imdsv2_token
+
 - name: Get mount source URL with availability zone
   uri:
     url: http://169.254.169.254/latest/meta-data/placement/availability-zone
+    headers:
+      X-aws-ec2-metadata-token: "{{ imdsv2_token.content }}"
     return_content: yes
   register: availability_zone
   when: not ansible_check_mode


### PR DESCRIPTION
When I use this role for EC2 instances that Instance metadata service version 2 (access token) enforced, following error has been occurred.

```
TASK [thiagoalmeidasa.aws_efs : Get mount source URL with availability zone] ***
fatal: [*my-server*]: FAILED! => {
  "changed": false,
  "connection": "close",
  "content": "",
  "content_length": "0",
  "content_type": "text/plain",
  "date": "***",
  "elapsed": 0,
  "msg": "Status code was 401 and not [200]: HTTP Error 401: Unauthorized",
  "redirected": false,
  "server": "EC2ws",
  "status": 401,
  "url": "http://169.254.169.254/latest/meta-data/placement/availability-zone"
}
```

This PR will solve this issue with getting IMDSv2 access token.